### PR TITLE
Update simpleGrid.js

### DIFF
--- a/src/js/simpleGrid.js
+++ b/src/js/simpleGrid.js
@@ -183,15 +183,10 @@
                     $bodyRows.to$().removeClass(options.duplicateItemClass);
 
                     // ignore those marked as deleted
-                    $bodyRows = $bodyRows.each(function (index, item) {
-                        if (!$(item).hasClass(options.deletedClass)) {
-                            return item;
+                    $bodyRows.each(function (item,index) {  //No idea why item & index are reversed, but debug and it works this way. Strange.
+                        if (!$(item).parent('tr').hasClass(options.deletedClass)) {
+                            names.push($(item).text());
                         }
-                    });
-
-                    // Build a sorted list of names
-                    $.each($tbl.DataTable().column(0).nodes(), function (index, item) {
-                        names.push($(item).text());
                     });
                     names = names.sort();
 


### PR DESCRIPTION
Right.  When reassigning to variable $bodyRows, the existing code doesn't seem to work, on top of the fact that deletedClass is assigned to the parent row, and we're working with an array of td elements.  There's the oddness that index and item are reversed in the $bodyRows.each implementation, which I just cannot understand (debug and you'll see that it works as I've modded it, but doesn't work with them in what jQuery's documentation says should be the case).
